### PR TITLE
reduced the aggressiveness of the scaling (from 10% to 25% of the bound)

### DIFF
--- a/dsp/graph_preprocessing.py
+++ b/dsp/graph_preprocessing.py
@@ -72,9 +72,10 @@ def scale_dataframe(df):
     # scale the EEG columns
     df_eeg = df[eeg_columns]
 
-    # new norm: scale to -1, 1 and then adjust it to a percentage of
+    # new norm: scale to -1, 1 and then adjust it to a percentage of so clean waveforms
+    #   arent reaching the bound (on average)
     bound = (median_max + abs(median_min)) / 2
-    scaled_eeg = (df_eeg / bound) * 0.1
+    scaled_eeg = (df_eeg / bound) * 0.25
 
     try: 
         # scale ECG column(s) separately


### PR DESCRIPTION
I noticed that the scaling was being too aggressive with the following AEA EEG cases:

-EEG-a7aaadc7-1fd9-4d86-874e-838cc09eb671
-EEG-8eed24cc-522a-4ca5-bdd3-663e8a6c146d
-EEG-b6af7b43-65ef-4c9a-9f17-9396bc8f7e7d
-EEG-f3ddfefa-089f-4a7b-9325-6df7b9305281
-EEG-0c1fa245-2902-4a60-938d-662850b0dc54

When scaling the data around a y-axis range of 1 using a median +- bound of peaks and troughs, this assumes that the user wants to see (on average) no space between stacked channel data. To reach the desired vertical spacing that results in more readable EEG waveforms, the data should be a percentage of this. This "percentage of" was changed from 10% to 25% to increase the vertical _reach_ of the average waveform within its bound.
