### PR TITLE
Protocol review updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.6] - 2025-02-18
+### Fixed
+- Protocols presets logic resets to previous business logic.
+
+
+
 ## [2.12.5] - 2025-02-18
 ### Fixed
 - Set other fields to be explicitly 0 after approval.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.12.5] - 2025-02-18
+### Fixed
+- Set other fields to be explicitly 0 after approval.
+- Add in phaseDuration, set to 0 as default in MeRT 2.
+
 ## [2.12.4] - 2025-02-17
 ### Fixed
 - Prevent user from saving null values in the protocol editor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "Wavelit"
-version = "2.12.4"
+version = "2.12.5"
 
 description = "A set of tools and dashboards for enhance EEG review for Wave Neuro's EEG lab"
 authors = ["Luis Camargo <lcamargo@waveneuro.com>", "Joseph Chong <joseph@waveneuro.com>"]

--- a/streamlit_apps/mert_components/protocol_review.py
+++ b/streamlit_apps/mert_components/protocol_review.py
@@ -387,11 +387,14 @@ def render_protocol_page(data_manager):
 
                     for param in  ("burstDuration", "burstFrequency", "burstNumber", "interBurstInterval"):
                         if phase_dict[param] == 0:
-                            phase_dict[param] = None
+                            phase_dict[param] = 0
 
                         # Ensure NaN values are explicitly converted to None
                         if pd.isna(phase_dict[param]):
                             phase_dict[param] = None
+
+                    # this field is added programmatically in MeRT 2
+                    phase_dict["phaseDuration"] = 0
 
                     phase_dict["pulseParameters"] = ast.literal_eval(phase_dict["pulseParameters"])
 

--- a/streamlit_apps/mert_components/protocol_review.py
+++ b/streamlit_apps/mert_components/protocol_review.py
@@ -393,8 +393,9 @@ def render_protocol_page(data_manager):
                         if pd.isna(phase_dict[param]):
                             phase_dict[param] = None
 
-                    # this field is added programmatically in MeRT 2
+                    # these field(s) are added programmatically in MeRT 2
                     phase_dict["phaseDuration"] = 0
+                    phase_dict["goalIntensity"] = 0
 
                     phase_dict["pulseParameters"] = ast.literal_eval(phase_dict["pulseParameters"])
 

--- a/streamlit_apps/mert_components/protocol_review.py
+++ b/streamlit_apps/mert_components/protocol_review.py
@@ -276,16 +276,9 @@ def render_protocol_page(data_manager):
         except Exception as e:
             st.error(f"Failed to add new phase: {str(e)}")
 
+
     if "phases" in st.session_state:
         phases = st.session_state["phases"]
-
-        for i, phase_dict in enumerate(protocol_data["phases"]):
-            phases[i] = phase_dict
-
-
-    if len(protocol_data["phases"]) > 1:
-        for i, phase_dict in enumerate(protocol_data["phases"]):
-            phases[i] = phase_dict
 
     for i, phase_dict in enumerate(phases):
         if "pulseParameters" in phase_dict:


### PR DESCRIPTION
Add protocol history on top of Protocol review page.
No longer store saved protocol phases to sessions state, allow presets to change treatment parameters to preset default.